### PR TITLE
Secures TMDB API key with environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 /captures
 .externalNativeBuild
 .cxx
-local.properties
 
+# Security: Files with sensitive data
+local.properties
+gradle.properties
+
+# IDE
 .idea/

--- a/SECURITY_SETUP.md
+++ b/SECURITY_SETUP.md
@@ -1,0 +1,77 @@
+# 🛡️ Security Setup - TMDB API Key Configuration
+
+## ⚠️ Important Security Notice
+This project requires a TMDB API key that must be configured as an environment variable for security reasons.
+
+## 🔧 Setup Instructions
+
+### 1. Get your TMDB API Key
+1. Go to [The Movie Database (TMDB)](https://www.themoviedb.org/)
+2. Create an account or log in
+3. Navigate to Settings > API
+4. Request an API key
+5. Copy your API key
+
+### 2. Configure API Key
+
+#### Option A: Environment Variable (Recommended for CI/CD)
+
+##### For macOS/Linux (Bash/Zsh):
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+echo 'export TMDB_API_KEY=your_actual_api_key_here' >> ~/.zshrc
+source ~/.zshrc
+```
+
+##### For Windows (PowerShell):
+```powershell
+[System.Environment]::SetEnvironmentVariable('TMDB_API_KEY', 'your_actual_api_key_here', 'User')
+```
+
+##### For Windows (Command Prompt):
+```cmd
+setx TMDB_API_KEY "your_actual_api_key_here"
+```
+
+#### Option B: Gradle Properties (Easier for local development)
+
+1. Copy `gradle.properties.example` to `gradle.properties`
+2. Replace `your_tmdb_api_key_here` with your actual API key
+3. **Never commit `gradle.properties` to version control**
+
+```bash
+cp gradle.properties.example gradle.properties
+# Edit gradle.properties and add your API key
+```
+
+### 3. Verify Configuration
+```bash
+echo $TMDB_API_KEY
+```
+
+## 🚨 Security Best Practices
+
+✅ **DO:**
+- Use environment variables for API keys
+- Keep local.properties in .gitignore
+- Never commit API keys to version control
+- Use different keys for development/production
+
+❌ **DON'T:**
+- Store API keys in code files
+- Share API keys in chat/email
+- Commit sensitive data to repositories
+- Use production keys in development
+
+## 🔧 Build Configuration
+
+The app will automatically:
+- Read the API key from the environment variable
+- Fail the build if the variable is not set
+- Securely inject the key into BuildConfig
+
+## 📝 Notes
+
+- If you get a build error, ensure `TMDB_API_KEY` environment variable is set
+- Restart your IDE after setting environment variables
+- The API key is only accessible in the app at runtime, not in the source code

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,12 @@ android {
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "TMDB_API_KEY", "\"${rootProject.extra["TMDB_API_KEY"]}\"")
+        val tmdbApiKey = System.getenv("TMDB_API_KEY") ?: project.findProperty("TMDB_API_KEY") as? String ?: ""
+        buildConfigField("String", "TMDB_API_KEY", "\"$tmdbApiKey\"")
+        
+        if (tmdbApiKey.isEmpty()) {
+            throw GradleException("TMDB_API_KEY is not set. Please set it as environment variable or in gradle.properties.")
+        }
     }
 
     buildTypes {

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -22,6 +22,6 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-# TMDB API Key - DO NOT COMMIT TO VERSION CONTROL
-# This should be moved to environment variables in production
-TMDB_API_KEY=3abc5f93e76fd7c3dbdfd790df363d4a
+# TMDB API Key - REPLACE WITH YOUR ACTUAL API KEY
+# Get your API key from: https://www.themoviedb.org/settings/api
+TMDB_API_KEY=your_tmdb_api_key_here


### PR DESCRIPTION
Enforces the use of environment variables for the TMDB API key to prevent accidental commits of the key to version control.

Adds a check to ensure the API key is set and throws an exception if it is not.

Provides clear instructions in SECURITY_SETUP.md on how to configure the API key using either environment variables or gradle.properties (for local development only, with a strong warning against committing gradle.properties).

Adds gradle.properties to .gitignore to prevent accidental commits
